### PR TITLE
fix: always display feature text above image on mobile & update copyright year

### DIFF
--- a/src/components/feature-box.tsx
+++ b/src/components/feature-box.tsx
@@ -11,16 +11,14 @@ export default function FeatureBox({
 }) {
   return (
     <div className="p-6 glass grid grid-cols-1 md:grid-cols-12 gap-10 items-center">
-      <div className="col-span-5">
+      <div className={`col-span-5 order-1 ${imgLeft ? "md:order-2" : "md:order-1"}`}>
         <p className="text-3xl font-semibold !mb-3">{title}</p>
         <p className="text-gray-300">{description}</p>
       </div>
       <img
         src={imgSrc}
         alt="Feature Image"
-        className={`rounded-lg col-span-7 border border-neutral-800 ${
-          imgLeft ? "order-first" : "order-last"
-        }`}
+        className={`rounded-lg col-span-7 border border-neutral-800 order-2 ${imgLeft ? "md:order-1" : "md:order-2"}`}
       />
     </div>
   );

--- a/src/pages/index.tsx
+++ b/src/pages/index.tsx
@@ -93,7 +93,7 @@ const Home: React.FC = () => {
 
       <div className="flex flex-col items-center mt-10">
         <p className="py-3 text-xs text-muted-foreground">
-          &copy; 2025 Pocket ID
+          &copy; {new Date().getFullYear()} Pocket ID
         </p>
       </div>
     </div>


### PR DESCRIPTION
This pull request addresses two issues:

Feature Box Mobile Layout:
- Ensured that in the mobile view, the feature text (title and description) always appears above the image, regardless of the imgLeft prop, as having the title sometimes above and sometimes below the image on mobile devices felt inconsistent and unnecessary.

Footer Copyright:
- Updated the displayed copyright year to the current year.

