### PR TITLE
Add sample Podman pod spec

### DIFF
--- a/docs/setup/installation.md
+++ b/docs/setup/installation.md
@@ -39,6 +39,160 @@ bash -c "$(wget -qLO - https://github.com/community-scripts/ProxmoxVE/raw/main/c
 
 Pocket ID is available as a template on the Community Apps store.
 
+### Podman
+
+You can run Pocket ID with Podman using a Pod spec similar to the one in the example below.
+
+<details>
+  <summary>`pocket-id.yaml`</summary>
+
+```yaml
+kind: Pod
+apiVersion: v1
+metadata:
+  labels:
+    app: pocket-id
+  annotations:
+    io.containers.autoupdate: registry
+  name: pocket-id
+spec:
+  containers:
+    - name: pocket-id
+      image: ghcr.io/pocket-id/pocket-id:latest
+      env:
+        - name: "PUBLIC_APP_URL"
+          value: "http://localhost"
+        - name: "TRUST_PROXY"
+          value: "false"
+        - name: "MAXMIND_LICENSE_KEY"
+          valueFrom:
+            secretKeyRef:
+              name: "pocket-id-env"
+              key: "MAXMIND_LICENSE_KEY"
+        - name: "CADDY_PORT"
+          value: "4000"
+        - name: "PUID"
+          value: "1000"
+        - name: "PGID"
+          value: "1000"
+        # Expose Caddy on a non-privileged port to be able to run as non-root
+        - name: "CADDY_PORT"
+          value: "4000"
+        - name: "BACKEND_PORT"
+          value: "8080"
+        - name: "PORT"
+          value: "3000"
+        - name: "DB_PROVIDER"
+          value: "sqlite" # "sqlite" or "postgres"
+        # For Postgres
+        # This is ignored if not using Postgres
+        - name: "POSTGRES_CONNECTION_STRING"
+          valueFrom:
+            secretKeyRef:
+              name: "pocket-id-env"
+              key: "POSTGRES_CONNECTION_STRING"
+        # Used by Caddy
+        - name: "XDG_DATA_HOME"
+          value: "/mnt/xdgdata/"
+        # Used by Caddy
+        - name: "XDG_CONFIG_HOME"
+          value: "/mnt/xdgconfig/"
+      ports:
+        - containerPort: 4000
+          hostPort: 4000
+      # These work because the container includes curl
+      # See: https://github.com/containers/podman/issues/18318
+      livenessProbe:
+        httpGet:
+          path: "/health"
+          # Caddy's port
+          port: 4000
+        failureThreshold: 3
+        initialDelaySeconds: 10
+        periodSeconds: 30
+        timeoutSeconds: 3
+      securityContext:
+        readOnlyRootFilesystem: true
+        runAsUser: 1000
+        runAsGroup: 1000
+      restart: Always
+      volumeMounts:
+        - name: pocket-id-data
+          mountPath: /app/backend/data
+        - name: pocket-id-xdgconfig
+          mountPath: /mnt/xdgconfig
+        - name: pocket-id-xdgdata
+          mountPath: /mnt/xdgdata
+      resources: {}
+
+  # In this example we are mounting volumes from the host
+  # Replace `/path/to/pocket-id` with the path on the host
+  # Make sure to set permissions with: `chmod -R 1000:1000 /path/to/pocket-id`
+  # If SELinux is enabled, also: `chcon -Rt svirt_sandbox_file_t /var/mnt/apps/pocketid` 
+  volumes:
+    # For SQLite database
+    - name: pocket-id-data
+      hostPath:
+        path: /path/to/pocket-id/data
+        type: Directory
+    # Used by Caddy
+    - name: pocket-id-xdgconfig
+      hostPath:
+        path: /path/to/pocket-id/xdgconfig
+        type: Directory
+    # Used by Caddy
+    - name: pocket-id-xdgdata
+      hostPath:
+        path: /path/to/pocket-id/xdgdata
+        type: Directory
+
+---
+kind: Secret
+apiVersion: v1
+metadata:
+  name: pocket-id-env
+type: Opaque
+stringData:
+  MAXMIND_LICENSE_KEY: ""
+  # Example
+  # This is ignored if not using postgres as database
+  POSTGRES_CONNECTION_STRING: "postgresql://user:password@host:5432/pocket-id"
+```
+
+</details>
+
+You can create the pod with:
+
+```sh
+podman play kube pocket-id.yaml
+```
+
+The Pod spec can also be run as a systemd service using a [Quadlet](https://docs.podman.io/en/latest/markdown/podman-systemd.unit.5.html) unit, for example:
+
+<details>
+  <summary>`pocket-id.kube`</summary>
+
+```conf
+[Unit]
+Description=Pocket ID service
+Requires=network-online.target local-fs.target
+After=network-online.target local-fs.target
+StartLimitIntervalSec=0
+
+[Service]
+Restart=always
+RestartSec=2s
+
+[Kube]
+Yaml=/etc/pods/pocket-id.yaml
+AutoUpdate=registry
+
+[Install]
+WantedBy=multi-user.target default.target
+```
+
+</details>
+
 ### Stand-alone Installation (advanced)
 
 Required tools:


### PR DESCRIPTION
Updates the installation document adding an example Pod spec to run with Podman (using `podman play kube`), as well as a sample Quadlet unit

Note: I was not able to run the development server locally. Running `npm install` and then `npm start` as per docs fails with:

```
[INFO] Starting the development server...
[ERROR] Sidebars file at "/Users/alessandro/Desktop/Code/pocket-id-website/sidebars.ts" failed to be loaded.
[ERROR] Loading of version failed for version current

[ERROR] Error: Docusaurus could not load module at path "/Users/alessandro/Desktop/Code/pocket-id-website/sidebars.ts"
Cause: Cannot find module './docs/api/endpoints/sidebar.ts'
```