### PR TITLE
docs: adds cookie_name to sample oauth2-proxy config

### DIFF
--- a/docs/guides/proxy-services.md
+++ b/docs/guides/proxy-services.md
@@ -163,7 +163,7 @@ email_domains = ["*"]
 # If you are using HTTPS
 cookie_secure="true"
 
-# Should use the "__Host-" or "__Secure-" prefix for HTTPS
+# With HTTPS use "__Host-" or "__Secure-" prefix, otherwise leave blank
 cookie_name="__Host-oauth2-proxy"
 
 # Listen on all interfaces

--- a/docs/guides/proxy-services.md
+++ b/docs/guides/proxy-services.md
@@ -163,6 +163,9 @@ email_domains = ["*"]
 # If you are using HTTPS
 cookie_secure="true"
 
+# Should use the "__Host-" or "__Secure-" prefix for HTTPS
+cookie_name="__Host-oauth2-proxy"
+
 # Listen on all interfaces
 http_address="0.0.0.0:4180"
 ```


### PR DESCRIPTION
This PR adds the recommended `cookie_name` variable from oauth2-proxy docs, to the config doc for that page.

From oauth2-proxy [docs](https://oauth2-proxy.github.io/oauth2-proxy/configuration/overview#cookie-options):

> The name of the cookie that the oauth_proxy creates. Should be changed to use a [cookie prefix](https://developer.mozilla.org/en-US/docs/Web/HTTP/Cookies#cookie_prefixes) (`__Host-` or `__Secure-`) if `--cookie-secure` is set.

This is somewhat of an opinionated change, but since `cookie_secure` was present in the Pocket ID recommended configuration before, the sample config should also probably include the recommended corresponding change to the name/prefix, to increase security and mitigate session fixation attacks.

This seems to work for me in testing, and everything I read seems to suggest this greatly improves security by domain-locking your cookies.

Any objections or thoughts?