### PR TITLE
docs: update Docker image reference in migration guide

### DIFF
--- a/docs/setup/migrate-v1.md
+++ b/docs/setup/migrate-v1.md
@@ -71,7 +71,7 @@ Follow the following steps to migrate from previous versions to v1.0.
    ```yaml
    services:
      pocket-id:
-       image: pocketid/pocket-id:latest
+       image: ghcr.io/pocket-id/pocket-id:latest
        ports:
          - "1411:1411" # Change the port
        volumes:


### PR DESCRIPTION
`pocketid/pocket-id:latest` doesn't exist (atleast publicly) on Docker Hub, so I've updated the migration guide's docker-compose.yml example to use the GitHub Container Repository