### PR TITLE
docs: Update pangolin.md to clarify callback URL setup

### DIFF
--- a/docs/client-examples/pangolin.md
+++ b/docs/client-examples/pangolin.md
@@ -7,7 +7,9 @@ id: pangolin
 ## Pocket ID Setup 
 
 1. In Pocket ID create a new OIDC Client, name it, for example, `pangolin`
-	- Copy the `Client ID`, `Client Secret`, `Authorization URL` and `Token URL` for the following steps
+2. In the "callback URL" field, enter any URL - this will be overwritten in a future step.
+	a. NOTE: You cannot proceed with generating the Client ID, Secret, Auth/Token URL's unless or until this field is filled out. This has been raised under a [Feature Request](https://github.com/pocket-id/pocket-id/issues/538)
+3. Copy the `Client ID`, `Client Secret`, `Authorization URL` and `Token URL` for the following steps
     
 We'll be coming back to set the Callback URL once we've setup Pangolin.
 


### PR DESCRIPTION
Add in guidance around callback URL for Pocket ID initial setup; this scenario specifically addresses configuration with Pangolin but may also apply to other applications that require a ID/Secret/Auth&Token URLs to be provided before a callback URL is generated.