### PR TITLE
docs: container security hardening

### DIFF
--- a/docs/setup/advanced-topics.md
+++ b/docs/setup/advanced-topics.md
@@ -16,6 +16,81 @@ proxy_buffers   4 512k;
 proxy_buffer_size   256k;
 ```
 
+## Container security hardening
+
+By default, the Pocket ID container starts as the root user, which is used to set permissions on the file system before dropping its privileges and starting the main process. This is done for convenience, while still running the Pocket ID binary as non-root.
+
+If you prefer, you can run the Pocket ID container as a **non-root** user entirely and even ensure it uses a **read-only root file system**.
+
+### Prerequisites
+
+Make sure that the Pocket ID data volume is writable by the chosen user. This is the volume/folder mounted in the container at `/app/data`.
+
+For example, if running the container as user `1000` and group `1000`, use a command similar to this to change the owner of the data folder:
+
+```sh
+# Set the owner to user 1000 and group 1000
+chown -R 1000:1000 ./data
+# Set permissions on all folders to 0700
+find ./data -type d -exec chmod 0700 {} \;
+# Set permissions on all files to 0600
+find ./data -type f -exec chmod 0600 {} \;
+```
+
+> Alternatively, you can start up the Pocket ID container with the default configuration once (where it starts as root before dropping privileges), and it will create the directories and set permissions automatically.
+
+### Container configuration
+
+To run the container as non-root and with a read-only root file system, use one of the options below.
+
+<details>
+  <summary>Docker CLI</summary>
+
+Add the `--user 1000:1000 --read-only` flags to the `docker run` command.
+</details>
+
+<details>
+  <summary>Docker Compose</summary>
+
+Set these options in the `pocket-id` service:
+
+- `read_only: true`
+- `user: "1000:1000"`
+
+Example:
+
+```yaml
+services:
+  pocket-id:
+    # ...
+    read_only: true
+    user: "1000:1000"
+```
+</details>
+
+<details>
+  <summary>Kubernetes Pod spec (including Podman)</summary>
+
+Set these options in the Pod's `securityContext`:
+
+- `readOnlyRootFilesystem: true`
+- `runAsUser: 1000`
+- `runAsGroup: 1000`
+
+Example:
+
+```yaml
+spec:
+  containers:
+    - name: "pocket-id"
+      # ...
+      securityContext:
+        readOnlyRootFilesystem: true
+        runAsUser: 1000
+        runAsGroup: 1000
+```
+</details>
+
 ## Use custom private keys
 
 By default, Pocket ID generates a RSA-2048 private key upon first startup, which is used to sign all tokens.

--- a/docs/setup/advanced-topics.md
+++ b/docs/setup/advanced-topics.md
@@ -43,53 +43,21 @@ find ./data -type f -exec chmod 0600 {} \;
 
 To run the container as non-root and with a read-only root file system, use one of the options below.
 
-<details>
-  <summary>Docker CLI</summary>
+- **Docker CLI**: Add the `--user 1000:1000 --read-only` flags to the `docker run` command.
+- **Docker Compose**: Set these options in the `pocket-id` service:
 
-Add the `--user 1000:1000 --read-only` flags to the `docker run` command.
-</details>
+   - `read_only: true`
+   - `user: "1000:1000"`
 
-<details>
-  <summary>Docker Compose</summary>
+   Example:
 
-Set these options in the `pocket-id` service:
-
-- `read_only: true`
-- `user: "1000:1000"`
-
-Example:
-
-```yaml
-services:
-  pocket-id:
-    # ...
-    read_only: true
-    user: "1000:1000"
-```
-</details>
-
-<details>
-  <summary>Kubernetes Pod spec (including Podman)</summary>
-
-Set these options in the Pod's `securityContext`:
-
-- `readOnlyRootFilesystem: true`
-- `runAsUser: 1000`
-- `runAsGroup: 1000`
-
-Example:
-
-```yaml
-spec:
-  containers:
-    - name: "pocket-id"
-      # ...
-      securityContext:
-        readOnlyRootFilesystem: true
-        runAsUser: 1000
-        runAsGroup: 1000
-```
-</details>
+   ```yaml
+   services:
+     pocket-id:
+       # ...
+       read_only: true
+       user: "1000:1000"
+   ```
 
 ## Use custom private keys
 


### PR DESCRIPTION
Includes instructions for running the container as non-root and with read-only root FS

See pocket-id/pocket-id#680