### PR TITLE
fix: incorrect image in sample

### DIFF
--- a/docs/advanced/hardening.md
+++ b/docs/advanced/hardening.md
@@ -68,7 +68,7 @@ This `docker-compose.yml` includes a full example of using Pocket ID's distroles
 ```yaml
 services:
   pocket-id:
-    image: ghcr.io/pocket-id/pocket-id:v1
+    image: ghcr.io/pocket-id/pocket-id:v1-distroless
     restart: unless-stopped
     env_file: .env
     ports:


### PR DESCRIPTION
The description references using distroless images, but the image used is the regular one