### PR TITLE
doc: rewrite Jellyfin client example for v10.11.2

### DIFF
--- a/docs/client-examples/jellyfin.md
+++ b/docs/client-examples/jellyfin.md
@@ -91,7 +91,7 @@ jellyfin_admins
 
 ## Optional Step - Custom Login Button on Main Page
 
-In the Jellyfin administration UI, under **Branding**, add the following code in the **Login disclaimer** block (replacing JELLYFIN_URL and the PROVIDER, e.g. `Pocket ID`):
+In the Jellyfin administration UI, under **Branding**, add the following code in the **Login disclaimer** block (replacing JELLYFIN_URL and the PROVIDER, e.g. `PocketID`):
 ```
 <form action="https://<JELLYFIN_URL>/sso/OID/start/<PROVIDER>">
   <button class="raised block emby-button button-submit">


### PR DESCRIPTION
Rewrites the Jellyfin client example documentation for Jellyfin v10.11.2 with updated features including profile picture support and group-based access control.

The guide is now split into two distinct setup paths:
- Basic setup (no groups, no admin differentiation)
- Advanced setup (with groups and admin roles)

Also includes:
- Updated QuickConnect workflow documentation
- Using Profile Pictures
- Browser-only SSO limitations warning
- Optional custom login button setup
- Fixed spelling and grammar issues
- Improved formatting consistency