### PR TITLE
docs: fix curl command syntax in installation guide

### DIFF
--- a/docs/setup/installation.md
+++ b/docs/setup/installation.md
@@ -16,9 +16,8 @@ You can use a reverse proxy like [Caddy](https://caddyserver.com/) or [NGINX](ht
 1. Download the [`docker-compose.yml`](https://raw.githubusercontent.com/pocket-id/pocket-id/main/docker-compose.yml) and [`.env`](https://raw.githubusercontent.com/pocket-id/pocket-id/main/.env.example) file:
 
    ```bash
-    curl -O https://raw.githubusercontent.com/pocket-id/pocket-id/main/docker-compose.yml
-
-    curl -o .env https://raw.githubusercontent.com/pocket-id/pocket-id/main/.env.example
+   curl -o docker-compose.yml https://raw.githubusercontent.com/pocket-id/pocket-id/main/docker-compose.yml
+   curl -o .env https://raw.githubusercontent.com/pocket-id/pocket-id/main/.env.example
    ```
 
 2. Edit the `.env` file so that it fits your needs. See the [environment variables](/docs/configuration/environment-variables) section for more information.


### PR DESCRIPTION
Fixed an error in the documentation. I came across this error, while i was trying it out moments ago.