### PR TITLE
Client-example vaultwarden: add security note to SSO_SIGNUPS_MATCH_EMAIL

### DIFF
--- a/docs/client-examples/vaultwarden.md
+++ b/docs/client-examples/vaultwarden.md
@@ -15,7 +15,7 @@ Set the following variables in your vaultwarden environment file, replace `<clie
 
 ```bash
 SSO_ENABLED=true
-SSO_SIGNUPS_MATCH_EMAIL=true
+SSO_SIGNUPS_MATCH_EMAIL=true #Only keep this on true if you are willing to accept the risks: https://github.com/dani-garcia/vaultwarden/wiki/Enabling-SSO-support-using-OpenId-Connect#on-sso_allow_unknown_email_verification
 SSO_ALLOW_UNKNOWN_EMAIL_VERIFICATION=true
 SSO_PKCE=true #Only set this to true if you enabled PKCE (recommended) in Pocket ID otherwise set it to false
 SSO_SCOPES=email profile groups offline_access


### PR DESCRIPTION
If SSO_ALLOW_UNKNOWN_EMAIL_VERIFICATION is set with SSO_SIGNUPS_MATCH_EMAIL=true, then a user can associate with an existing, non-SSO account, even if they do not control the email address. This allow a user to gain access to sensitive information (even though the master password is still required to read the passwords)