### PR TITLE
Fix typo in 'Audiobookshelf' heading

### DIFF
--- a/docs/client-examples/audiobookshelf.md
+++ b/docs/client-examples/audiobookshelf.md
@@ -37,7 +37,7 @@ The following example variables are used, and should be replaced with your actua
 
 If you want to automatically assign permissions based on group membership.
 
-#### Audiobooshelf
+#### Audiobookshelf
 
 Set the **Group Claim** under **Settings → Authentication → OpenID Connect Authentication → Group Claim** to `groups`.
 


### PR DESCRIPTION
Quick typo fix I noticed during my own configuration