### PR TITLE
feat: add role mapping to grafana example

### DIFF
--- a/docs/client-examples/grafana.md
+++ b/docs/client-examples/grafana.md
@@ -37,6 +37,15 @@ Below URLs are used as placeholders for the Grafana and Pocket ID instances. Rep
 7. Next create a new admin user or update the existing admin user under the **Users** settings to have the same email address as your user in **Pocket-ID**. Also set the username to the same email id.
 8. Logout and test the OAuth based login.
 
+## Role Mapping
+
+To use group membership to assign roles automatically:
+
+1. Add `groups` to the `Scopes` setting: `openid email profile groups`
+2. Set the `role attribute path` according to the [examples](https://grafana.com/docs/grafana/latest/setup-grafana/configure-access/configure-authentication/generic-oauth/). For example:
+   - `role_attribute_path: contains(groups[*], 'Monitoring Admin') && 'Admin' || contains(groups[*], 'Monitoring') && 'Editor' || 'Viewer'` will grant the "Admin" role to anyone with the "Monitoring Admin" group, the "Editor" role to anyone with the "Monitoring" group, and the "Viewer" role to any other logged-in user.
+3. Logout and back in to update your role.
+
 ## Common problems
 
 - In case you get locked out of your account before the OAuth setup is completed successfully and need to reset the password refer this [link](https://grafana.com/docs/grafana/latest/cli/#reset-admin-password).


### PR DESCRIPTION
Added role mapping instructions for OAuth setup in Grafana.

No AI.