### PR TITLE
doc: add step for Beszel email verification

### DIFF
--- a/docs/client-examples/beszel.md
+++ b/docs/client-examples/beszel.md
@@ -22,6 +22,7 @@ description: Set up Pocket ID authentication for Beszel
 
 1. Open the Pocket ID settings page and navigate to **`Application Configuration`**.
 2. Enable **Emails Verified**.
+3. Navigate to **Users** and select the user account. Ensure the email address is marked as Verified. If the icon next to the email is not green, click it to manually toggle the status to verified.
 
 > [!NOTE]
 > Beszel requires the OAuth provider to return a valid, verified email address to create new users.  


### PR DESCRIPTION
Updated the Beszel client example to explicitly state that the user's email must be marked as "Verified" in Pocket ID, ensuring successful account creation on first login. 

It took me a while to realise that my email wasn't verified. As far as I understand, the "Emails verified by default" switch only works for new users. For existing users, it has to be activated manually.  