### PR TITLE
docs: Revise Nextcloud OIDC Client setup instructions

### DIFF
--- a/docs/client-examples/nextcloud.md
+++ b/docs/client-examples/nextcloud.md
@@ -16,7 +16,7 @@ The following example variables are used and should be replaced with your actual
 2. Set a logo for this OIDC Client if you would like to.
 3. Set the callback URL to: `https://nextcloud.example.com/apps/user_oidc/code`, or leave blank to autofill on first login.
 4. Set the Logout Callback URLs to the address the nextcloud/user_oidc plugin will give you. For most of the time it will be the address below with the portion `PocketID` being the name you gave to it on Nextcloud. e.g:`https://nextcloud.example.com/apps/user_oidc/backchannel-logout/PocketID`.
-5. Leave `Public Client` and `PKCE` unchecked.
+5. Leave `Public Client` unchecked. Consider enabling `PKCE`.
 6. Copy the `Client ID`, `Client Secret`, `OIDC Discovery URL` and `Logout URL` for use in the next steps.
 
 ## Nextcloud Setup


### PR DESCRIPTION
> This app supports PKCE (Proof Key for Code Exchange)
https://github.com/nextcloud/user_oidc

There is no reason to recommend that new users leave it unchecked. This change forces them to inform themselves and make their own choice.