### PR TITLE
docs(portainer): remove note about Business Edition requirement

### DIFF
--- a/docs/client-examples/portainer.md
+++ b/docs/client-examples/portainer.md
@@ -3,8 +3,6 @@ title: Portainer
 description: Set up Portainer container management with OIDC
 ---
 
-**This requires Portainers Business Edition**
-
 The following example variables are used, and should be replaced with your actual URLS.
 
 - portainer.example.com (The url of your Portainer instance.)


### PR DESCRIPTION
Navigating the Portainer UI, I just realized that Business edition is not required to setup OAuth & I was able to setup everything successfull with PocketID

<img width="1712" height="530" alt="image" src="https://github.com/user-attachments/assets/cfe0f7d6-b255-4021-82d5-797bb854f268" />
