### PR TITLE
docs: add Installation for Homebrew

### DIFF
--- a/docs/setup/installation.md
+++ b/docs/setup/installation.md
@@ -26,12 +26,6 @@ You can use a reverse proxy like [Caddy](https://caddyserver.com/) or [NGINX](ht
 
 Create an admin account on `https://<your-app-url>/setup`.
 
-### Installation with Homebrew
-
-   ```bash
-   brew install pocket-id
-   ```
-
 ### Stand-alone Installation
 
 1. Download the latest binary from the [releases page](https://github.com/pocket-id/pocket-id/releases/latest).
@@ -112,6 +106,12 @@ It can be enabled by adding the following to your `configuration.nix`:
 ```
 
 For further configuration of the module, see the available [settings](https://search.nixos.org/options?channel=unstable&from=0&size=50&sort=relevance&type=packages&query=pocket-id).
+
+### Homebrew
+
+   ```bash
+   brew install pocket-id
+   ```
 
 ## Installation from Source
 

--- a/docs/setup/installation.md
+++ b/docs/setup/installation.md
@@ -26,6 +26,12 @@ You can use a reverse proxy like [Caddy](https://caddyserver.com/) or [NGINX](ht
 
 Create an admin account on `https://<your-app-url>/setup`.
 
+### Installation with Homebrew
+
+   ```bash
+   brew install pocket-id
+   ```
+
 ### Stand-alone Installation
 
 1. Download the latest binary from the [releases page](https://github.com/pocket-id/pocket-id/releases/latest).


### PR DESCRIPTION
Pocket ID is now [available](https://github.com/Homebrew/homebrew-core/commit/3a8294e7c538f72f134914188bf998fbce6cc2d5) to install with [Homebrew](https://brew.sh).