### PR TITLE
doc: Add link to Kubernetes Operator in installation guide

### DIFF
--- a/docs/setup/installation.md
+++ b/docs/setup/installation.md
@@ -139,6 +139,7 @@ Pocket ID is available as a template on the Community Apps store.
 
 - A Helm chart maintained by @matslarson is available [here](https://github.com/matslarson/pocket-id-helm).
 - A Helm chart maintained by anza-labs [here](https://artifacthub.io/packages/helm/anza-labs/pocket-id).
+- A Kubernetes Operator maintained by @aclerici38 [here](https://github.com/aclerici38/pocket-id-operator).
 
 ### NixOS
 


### PR DESCRIPTION
Hi there

I use pocket-id in my homelab on docker and latley on kubernetes. 

The only downside I could find so far is that it does not fit the gitops process.

I've found this k8s operator which close this gap by providing gitops capabillities.

To make it more popular we should have it on the documentation web site.

Thanks