### PR TITLE
docs: add bytestash client example

### DIFF
--- a/docs/client-examples/bytestash.md
+++ b/docs/client-examples/bytestash.md
@@ -1,0 +1,17 @@
+---
+title: ByteStash
+description: Configure ByteStash with Pocket ID authentication
+---
+
+1. Create a new OIDC Client in Pocket ID (e.g., `ByteStash`).
+2. Set the Callback URL to `https://{bytestash_host}/api/oauth/openid`, or leave blank to autofill on first login.
+3. _(Optional)_ Find and upload a logo from [Self-Hosted Dashboard Icons](https://selfh.st/icons)
+4. Configure ByteStash environment variables
+
+   - `OIDC_ENABLED`: Set to `true` to enable OIDC authentication.
+   - `OIDC_DISPLAY_NAME`: The lowercase name of the provider (`pocketid`).
+   - `OIDC_ISSUER_URL`: The authorization URL for you Pocket ID instance, e.g. `https://id.host.local`.
+   - `OIDC_CLIENT_ID`: The client ID copied from Pocket ID.
+   - `OIDC_CLIENT_SECRET`: The client secret copied from Pocket ID.
+
+5. Set up your email address in ByteStash. This email has to match your user email in Pocket ID.


### PR DESCRIPTION
Client example for [ByteStash ](https://github.com/jordan-dalby/ByteStash). I've tested this on my own setup.


**Note**
pnpm dev gives me a few errors about missing titles in the following existing three pages. My page compiles perfectly fine.. ;)

```
[VELITE] issues:
docs/client-examples/dbackup.md
 error Required  description
 error Required  title

docs/client-examples/dockhand.md
 error Required  description
 error Required  title

docs/client-examples/readmeabook.md
 error Required  description
 error Required  title

✖ 6 errors
```