### PR TITLE
Fix path to Pocket ID logo in Gitlab config

### DIFF
--- a/docs/client-examples/gitlab.md
+++ b/docs/client-examples/gitlab.md
@@ -32,7 +32,7 @@ gitlab_rails['omniauth_providers'] = [
   {
     name: "openid_connect",
     label: "Pocket ID",
-    icon: "https://oidc.example.com/api/application-configuration/logo",
+    icon: "https://oidc.example.com/api/application-images/logo",
     args: {
       name: "openid_connect",
       scope: ["openid","profile","email"],


### PR DESCRIPTION
Fixed a small issue with the logo URL pointing to `/api/application-configuration/logo` instead of `/api/application-images/logo`.

Tested and working on the latest version of Pocket ID (2.12.0):
- `/api/application-configuration/logo` returns 404
- `/api/application-images/logo` returns the image