### PR TITLE
refactor(api): use mdsx table component and resolve schema $ref

### DIFF
--- a/src/lib/components/openapi-spec.svelte
+++ b/src/lib/components/openapi-spec.svelte
@@ -3,7 +3,9 @@
   import yaml from 'js-yaml';
   import Badge from '$lib/components/ui/badge/badge.svelte';
   import * as Accordion from '$lib/components/ui/accordion/index.js';
-  import { indexOpenApi, filterIndexed } from '$lib/utils/openapi-util.js';
+  import SchemaView from '$lib/components/schema-view.svelte';
+  import { td as Td, th as Th, tr as Tr } from '$lib/components/mdsx/index.js';
+  import { indexOpenApi, filterIndexed, definitionLabel } from '$lib/utils/openapi-util.js';
 
   interface Props {
     src?: string;
@@ -52,19 +54,6 @@
       delete: 'bg-red-500',
     };
     return colors[method.toLowerCase()] || 'bg-gray-500';
-  }
-
-  function formatPropertyType(property: any): string {
-    if (property.type) {
-      if (property.type === 'array' && property.items) {
-        return `${property.type}<${formatPropertyType(property.items)}>`;
-      }
-      return property.type;
-    }
-    if (property.$ref) {
-      return property.$ref.split('/').pop() || 'object';
-    }
-    return 'unknown';
   }
 
   function getEndpointsByTag(paths: Record<string, Record<string, any>>) {
@@ -157,6 +146,9 @@
 
             <Accordion.Root type="multiple" class="space-y-2">
               {#each filtered[tagName] as ep, index}
+                {@const parameters = ep.operation.parameters ?? []}
+                {@const body = parameters.find((p: any) => p.in === 'body')}
+                {@const otherParams = parameters.filter((p: any) => p.in !== 'body')}
                 <Accordion.Item variant="card" value="endpoint-{tagName}-{index}">
                   <Accordion.Trigger class="px-4 py-3 hover:no-underline">
                     <div class="flex items-center gap-3 w-full text-left">
@@ -185,43 +177,34 @@
                       {/if}
 
                       <!-- Parameters -->
-                      {#if ep.operation.parameters && ep.operation.parameters.length > 0}
-                        <div>
-                          <h4 class="font-semibold mb-3">Parameters</h4>
-                          <div class="overflow-x-auto">
-                            <table class="w-full border-collapse border border-border">
+                      {#if otherParams.length > 0}
+                        <div class="space-y-2">
+                          <h4 class="font-semibold">Parameters</h4>
+                          <div class="w-full overflow-x-auto">
+                            <table class="w-full border-none text-sm">
                               <thead>
-                                <tr class="bg-muted">
-                                  <th class="border border-border p-2 text-left">Name</th>
-                                  <th class="border border-border p-2 text-left">Type</th>
-                                  <th class="border border-border p-2 text-left">In</th>
-                                  <th class="border border-border p-2 text-left">Required</th>
-                                  <th class="border border-border p-2 text-left">Description</th>
-                                </tr>
+                                <Tr>
+                                  <Th>Name</Th>
+                                  <Th>Type</Th>
+                                  <Th>In</Th>
+                                  <Th>Description</Th>
+                                </Tr>
                               </thead>
                               <tbody>
-                                {#each ep.operation.parameters as param}
-                                  <tr>
-                                    <td class="border border-border p-2">
-                                      <code class="text-sm">{param.name}</code>
-                                    </td>
-                                    <td class="border border-border p-2">
-                                      <Badge variant="outline">{param.type || 'string'}</Badge>
-                                    </td>
-                                    <td class="border border-border p-2">
-                                      <Badge variant="secondary">{param.in}</Badge>
-                                    </td>
-                                    <td class="border border-border p-2">
+                                {#each otherParams as param}
+                                  <Tr>
+                                    <Td class="whitespace-nowrap align-top">
+                                      <code>{param.name}</code>
                                       {#if param.required}
-                                        <Badge variant="destructive">Required</Badge>
-                                      {:else}
-                                        <Badge variant="outline">Optional</Badge>
+                                        <span class="text-destructive ml-1 text-xs">required</span>
                                       {/if}
-                                    </td>
-                                    <td class="border border-border p-2 text-sm text-muted-foreground">
-                                      {param.description || ''}
-                                    </td>
-                                  </tr>
+                                    </Td>
+                                    <Td class="text-muted-foreground align-top font-mono text-xs">
+                                      {param.type || 'string'}
+                                    </Td>
+                                    <Td class="text-muted-foreground align-top text-xs">{param.in}</Td>
+                                    <Td class="text-muted-foreground align-top">{param.description || ''}</Td>
+                                  </Tr>
                                 {/each}
                               </tbody>
                             </table>
@@ -230,25 +213,18 @@
                       {/if}
 
                       <!-- Request Body -->
-                      {#if ep.operation.requestBody}
-                        <div>
-                          <h4 class="font-semibold mb-3">Request Body</h4>
-                          <div class="space-y-2">
-                            {#if ep.operation.requestBody.description}
-                              <p class="text-sm text-muted-foreground">{ep.operation.requestBody.description}</p>
+                      {#if body}
+                        <div class="space-y-2">
+                          <div class="flex flex-wrap items-center gap-2">
+                            <h4 class="font-semibold">Request Body</h4>
+                            {#if !body.required}
+                              <span class="text-muted-foreground text-xs">optional</span>
                             {/if}
-                            {#if ep.operation.requestBody.content}
-                              {#each Object.entries(ep.operation.requestBody.content) as [contentType, content]}
-                                <div>
-                                  <Badge variant="outline" class="mb-2">{contentType}</Badge>
-                                  {#if (content as any).schema}
-                                    <pre class="bg-muted p-3 rounded text-sm overflow-x-auto"><code
-                                        >{JSON.stringify((content as any).schema, null, 2)}</code></pre>
-                                  {/if}
-                                </div>
-                              {/each}
+                            {#if body.description}
+                              <span class="text-sm text-muted-foreground">{body.description}</span>
                             {/if}
                           </div>
+                          <SchemaView {spec} schema={body.schema} />
                         </div>
                       {/if}
 
@@ -273,11 +249,7 @@
                                 </div>
 
                                 {#if response.schema}
-                                  <div class="mt-2">
-                                    <h5 class="text-sm font-medium mb-1">Schema:</h5>
-                                    <pre class="bg-muted p-2 rounded text-xs overflow-x-auto"><code
-                                        >{JSON.stringify(response.schema, null, 2)}</code></pre>
-                                  </div>
+                                  <SchemaView {spec} schema={response.schema} />
                                 {/if}
                               </div>
                             {/each}
@@ -308,7 +280,7 @@
             <Accordion.Item variant="card" value="model-{index}">
               <Accordion.Trigger class="px-4 py-3 hover:no-underline">
                 <div class="flex items-center gap-3 w-full text-left">
-                  <code class="font-mono text-sm">{modelName}</code>
+                  <code class="font-mono text-sm">{definitionLabel(modelName)}</code>
                   {#if model.description}
                     <span class="text-sm text-muted-foreground truncate flex-1">{model.description}</span>
                   {/if}
@@ -316,43 +288,7 @@
               </Accordion.Trigger>
 
               <Accordion.Content class="px-4 pb-4">
-                {#if model.properties}
-                  <div class="overflow-x-auto">
-                    <table class="w-full border-collapse border border-border">
-                      <thead>
-                        <tr class="bg-muted">
-                          <th class="border border-border p-2 text-left">Property</th>
-                          <th class="border border-border p-2 text-left">Type</th>
-                          <th class="border border-border p-2 text-left">Required</th>
-                          <th class="border border-border p-2 text-left">Description</th>
-                        </tr>
-                      </thead>
-                      <tbody>
-                        {#each Object.entries(model.properties) as [propName, propSchema]}
-                          {@const schema = propSchema as { description?: string }}
-                          <tr>
-                            <td class="border border-border p-2">
-                              <code class="text-sm">{propName}</code>
-                            </td>
-                            <td class="border border-border p-2">
-                              <Badge variant="outline">{formatPropertyType(schema)}</Badge>
-                            </td>
-                            <td class="border border-border p-2">
-                              {#if model.required && model.required.includes(propName)}
-                                <Badge variant="destructive">Required</Badge>
-                              {:else}
-                                <Badge variant="outline">Optional</Badge>
-                              {/if}
-                            </td>
-                            <td class="border border-border p-2 text-sm text-muted-foreground">
-                              {schema.description || ''}
-                            </td>
-                          </tr>
-                        {/each}
-                      </tbody>
-                    </table>
-                  </div>
-                {/if}
+                <SchemaView {spec} schema={{ $ref: `#/definitions/${modelName}` }} />
               </Accordion.Content>
             </Accordion.Item>
           {/each}
@@ -361,10 +297,3 @@
     {/if}
   </div>
 {/if}
-
-<style>
-  pre {
-    white-space: pre-wrap;
-    word-break: break-word;
-  }
-</style>

--- a/src/lib/components/schema-view.svelte
+++ b/src/lib/components/schema-view.svelte
@@ -1,0 +1,66 @@
+<script lang="ts">
+  import ChevronDownIcon from '@lucide/svelte/icons/chevron-down';
+  import { td as Td, th as Th, tr as Tr } from '$lib/components/mdsx/index.js';
+  import { resolveSchema } from '$lib/utils/openapi-util.js';
+  import SchemaView from './schema-view.svelte';
+
+  let { spec, schema }: { spec: any; schema: any } = $props();
+
+  let resolved = $derived(resolveSchema(spec, schema));
+  let expanded = $state<Record<string, boolean>>({});
+</script>
+
+<div class="space-y-2">
+  <code class="text-sm">{resolved.label}</code>
+
+  {#if resolved.properties.length > 0}
+    <div class="w-full overflow-x-auto">
+      <table class="w-full border-none text-sm">
+        <thead>
+          <Tr>
+            <Th>Property</Th>
+            <Th>Type</Th>
+            <Th>Description</Th>
+          </Tr>
+        </thead>
+        <tbody>
+          {#each resolved.properties as property}
+            <Tr class="transition-colors {expanded[property.name] ? 'bg-muted/30' : ''}">
+              <Td class="whitespace-nowrap align-top">
+                <code>{property.name}</code>
+                {#if property.required}
+                  <span class="text-destructive ml-1 text-xs">required</span>
+                {/if}
+              </Td>
+              <Td class="text-muted-foreground align-top font-mono text-xs">
+                {#if property.expandable}
+                  <button
+                    type="button"
+                    class="hover:text-foreground flex cursor-pointer items-center gap-1 transition-colors"
+                    aria-expanded={!!expanded[property.name]}
+                    onclick={() => (expanded[property.name] = !expanded[property.name])}>
+                    {property.label}
+                    <ChevronDownIcon
+                      class="size-3 shrink-0 transition-transform duration-200 {expanded[property.name] ?
+                        'rotate-180'
+                      : ''}" />
+                  </button>
+                {:else}
+                  {property.label}
+                {/if}
+              </Td>
+              <Td class="text-muted-foreground align-top">{property.schema.description ?? ''}</Td>
+            </Tr>
+            {#if expanded[property.name]}
+              <Tr>
+                <Td colspan={3} class="border-primary/40 bg-muted/30 border-l-2">
+                  <SchemaView {spec} schema={property.schema} />
+                </Td>
+              </Tr>
+            {/if}
+          {/each}
+        </tbody>
+      </table>
+    </div>
+  {/if}
+</div>

--- a/src/lib/utils/openapi-util.ts
+++ b/src/lib/utils/openapi-util.ts
@@ -1,3 +1,46 @@
+const refKey = (ref: string) => ref.split('/').pop() ?? ref;
+
+/** Shortens the generics swag emits: `..._dto.Paginated-dto_UserDto` -> `Paginated[UserDto]`. */
+export function definitionLabel(key: string): string {
+  const generic = key.match(/\.(\w+)-\w+_(\w+)$/);
+  return generic ? `${generic[1]}[${generic[2]}]` : key;
+}
+
+/** Human readable type, e.g. `array<dto.UserDto>`, `map<string, string>` or `approve | deny`. */
+function schemaLabel(schema: any): string {
+  if (schema.$ref) return definitionLabel(refKey(schema.$ref));
+  if (schema.enum) return schema.enum.join(' | ');
+  if (schema.items) return `array<${schemaLabel(schema.items)}>`;
+  const values = schema.additionalProperties;
+  return typeof values === 'object' ? `map<string, ${schemaLabel(values)}>` : (schema.type ?? 'object');
+}
+
+/** Follows a `$ref` and unwraps arrays down to the schema being described. */
+function unwrap(spec: any, schema: any): any {
+  if (schema?.items) return unwrap(spec, schema.items);
+  return schema?.$ref ? unwrap(spec, spec.definitions?.[refKey(schema.$ref)]) : (schema ?? {});
+}
+
+/**
+ * Resolves a schema to its display type plus the properties of the definition behind it.
+ * Arrays are unwrapped, so `array<dto.UserDto>` lists a user's fields.
+ */
+export function resolveSchema(spec: any, schema: any) {
+  const base = unwrap(spec, schema);
+  const required: string[] = base.required ?? [];
+
+  return {
+    label: schemaLabel(schema),
+    properties: Object.entries<any>(base.properties ?? {}).map(([name, property]) => ({
+      name,
+      schema: property,
+      label: schemaLabel(property),
+      expandable: !!unwrap(spec, property).properties,
+      required: required.includes(name),
+    })),
+  };
+}
+
 export interface IndexedEndpoint {
   tag: string;
   path: string;


### PR DESCRIPTION
The current api docs render with unresolved refs, for example checking the response for GET `/api/users` shows `"$ref": "#/definitions/github_com_pocket-id_pocket-id_backend_internal_dto.Paginated-dto_UserDto"` which isn't super helpful without scrolling to the Data Models at the bottom.
This refactors the api page to always walk `$ref`, resolving each $ref inline.

Other changes:

- The request bodies expected `requestBody` but the swagger spec uses `in: body`, so request bodies now properly show the parameters
- The generic `github_com_pocket-id_pocket-id_backend_internal...` naming output by swag has been shortened for readability and formatting `github_com_pocket-id_pocket-id_backend_internal_dto.Paginated-dto_UserDto  →  Paginated[UserDto]`
- `required` moved from its own column to red text after the property

While adding this I thought the tables were too congested, and adopted the existing mdsx tr/th/td components used elsewhere in the site. I have spent lots of time on the env variables page and tried to adopt that look. I think this is nicer and more consistent but I can revert it if need be.
Screenshots:
Before
<img width="928" height="679" alt="Screenshot 2026-08-11 at 1 06 56 AM" src="https://github.com/user-attachments/assets/db731eb0-a9dc-4e9b-aaa6-9f7d5b569534" />
After
<img width="915" height="708" alt="Screenshot 2026-08-11 at 1 07 37 AM" src="https://github.com/user-attachments/assets/f6a28a72-f198-473e-88d0-b93d04cf6a53" />
With the ref expanded:
<img width="904" height="919" alt="Screenshot 2026-08-11 at 1 08 09 AM" src="https://github.com/user-attachments/assets/5a677acb-414c-4103-b3b1-dde75c3136ee" />
Nested refs
<img width="918" height="952" alt="Screenshot 2026-08-11 at 1 08 35 AM" src="https://github.com/user-attachments/assets/47baa7dd-d7a8-40f1-a2c5-bef8af4f0a01" />

Before:
<img width="920" height="557" alt="Screenshot 2026-08-11 at 1 11 19 AM" src="https://github.com/user-attachments/assets/704e5961-6dc2-4c89-bc63-58b3161899bc" />
After (note the request body):
<img width="927" height="1138" alt="Screenshot 2026-08-11 at 1 11 39 AM" src="https://github.com/user-attachments/assets/fbdf8b09-cb09-4fd4-8e70-6190db96cc9f" />

Alternatives considered:
Hyperlink to the matching Data Model. I thought it would be cleaner and easier to approach it inside the requests table instead of creatign a bunch of anchors for the data models.

AI DISCLOSURE:
The ideas and initial implementation on the old-style tables were my own. I used Opus 5 to clean up my logic, visual aspects, and refactor to the mdsx components used elsewhere.

Let me know if there's anything you'd prefer to change. Thanks!