### PR TITLE
docs: Add missing config for Redirect URL to WallOS example page

### DIFF
--- a/docs/client-examples/wallos.md
+++ b/docs/client-examples/wallos.md
@@ -27,9 +27,10 @@ Below URLs are used as placeholders for the [Wallos] and Pocket ID instances. Re
    - **Auth URL**
    - **Token URL**
    - **User info URL**.
-3. _Optional:_ Enable Create User automatically.   
-4. Turn the OIDC toggle on
-5. Save the settings.
-6. Test the OAuth login to ensure it works.
+3. _Optional:_ Enable Create User automatically.
+4. Set **Redirect URL** to wallos.example.com/index.php
+5. Turn the OIDC toggle on
+6. Save the settings.
+7. Test the OAuth login to ensure it works.
 
 [Wallos]: https://github.com/ellite/Wallos#readme


### PR DESCRIPTION
Since WallOS 5.4.4 (at least), the Redirect URL seems to be required to get the button "Login with Pocket ID". This commit adds that information to the WallOS client example.