### PR TITLE
docs: Update Desktop & Mobile OIDC client creation in opencloud

### DIFF
--- a/docs/client-examples/opencloud.md
+++ b/docs/client-examples/opencloud.md
@@ -82,11 +82,10 @@ OpenCloud's desktop and mobile clients send hardcoded `client_id` values that ca
    ```
 4. Enable **Public Client**.
 5. Enable **PKCE**.
-6. Save and copy the **Client ID** (a UUID) — you will need it in Step 4.
-7. Click **Show Advanced Options**
-8. Set the **Client ID** to `OpenCloudDesktop`
-9. Optionally restrict access under **Allowed Groups** to the four opencloud groups created in Step 1.
-10. Save
+6. Click **Show Advanced Options**
+7. Set the **Client ID** to `OpenCloudDesktop`
+8. Optionally restrict access under **Allowed Groups** to the four opencloud groups created in Step 1.
+9. Save
 
 ### Android
 
@@ -98,11 +97,10 @@ OpenCloud's desktop and mobile clients send hardcoded `client_id` values that ca
    ```
 4. Enable **Public Client**.
 5. Enable **PKCE**.
-6. Save and copy the **Client ID** (a UUID) — you will need it in Step 4.
-7. Click **Show Advanced Options**
-8. Set the **Client ID** to `OpenCloudAndroid`
-9. Optionally restrict access under **Allowed Groups** to the four opencloud groups created in Step 1.
-10. Save
+6. Click **Show Advanced Options**
+7. Set the **Client ID** to `OpenCloudAndroid`
+8. Optionally restrict access under **Allowed Groups** to the four opencloud groups created in Step 1.
+9. Save
 
 ### iOS
 
@@ -114,11 +112,10 @@ OpenCloud's desktop and mobile clients send hardcoded `client_id` values that ca
    ```
 4. Enable **Public Client**.
 5. Enable **PKCE**.
-6. Save and copy the **Client ID** (a UUID) — you will need it in Step 4.
-7. Click **Show Advanced Options**
-8. Set the **Client ID** to `OpenCloudIOS`
-9. Optionally restrict access under **Allowed Groups** to the four opencloud groups created in Step 1.
-10. Save
+6. Click **Show Advanced Options**
+7. Set the **Client ID** to `OpenCloudIOS`
+8. Optionally restrict access under **Allowed Groups** to the four opencloud groups created in Step 1.
+9. Save
 
 ---
 


### PR DESCRIPTION
The Desktop and Mobile OIDC instructions are not accurate.

Removed step #6 "Save and copy the Client ID (a UUID) — you will need it in Step 4." when creating a new Desktop or Mobile OIDC client because this is wrong.

When creating a new OIDC client in PocketID, you must enter the custom Client ID before saving the new client. You cannot change the Client ID once you save the new OIDC client and the current instructions say to save and then change the Client ID which you can't do.

Also, the instructions say to copy the Desktop or Mobile Client ID for use in Step 4 which is not correct. You must use the web Client ID in your Docker Compose file, not the Desktop or Mobile Client ID.

Removing this step provides clearer instructions that you need to use the Client ID OpenCloudDesktop/OpenCloudAndroid/OpenCloudIOS as the Client ID when initiallly creating these OIDC clients